### PR TITLE
Update gitignore to ignore process.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# CircleCI
+process.yml


### PR DESCRIPTION
This will update gitignore to ignore process.yml, as it is a file used to run CircleCI jobs locally.