### PR TITLE
Add readthedocs config and requirements for doc building

### DIFF
--- a/docs/readthedocs.yml
+++ b/docs/readthedocs.yml
@@ -1,0 +1,16 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx==2.1.2
+sphinx-click==2.3.0
+sphinx-rtd-theme==0.4.3


### PR DESCRIPTION
Should allow readthedocs to install sphinx-click, and close #57 